### PR TITLE
ARTEMIS-5948 Use Varhandle implementations from jctools

### DIFF
--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -74,6 +74,7 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-text/${commons.text.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang.version}</bundle>
 		<bundle dependency="true">mvn:org.jctools/jctools-core/${jctools.version}</bundle>
+		<bundle dependency="true">mvn:org.jctools/jctools-core-jdk11/${jctools.version}</bundle>
 		<bundle dependency="true">mvn:org.hdrhistogram/HdrHistogram/${hdrhistogram.version}</bundle>
 		<bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/${caffeine.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-dbcp2/${commons.dbcp2.version}</bundle>

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
@@ -42,7 +42,7 @@ import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.impl.SimpleWaitIOCallback;
 import org.apache.activemq.artemis.core.server.ActiveMQScheduledComponent;
 import org.apache.activemq.artemis.utils.ReusableLatch;
-import org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.varhandle.MpscUnboundedVarHandleArrayQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,7 @@ public class JDBCSequentialFile implements SequentialFile {
 
    private final JDBCSequentialFileFactoryDriver dbDriver;
 
-   MpscUnboundedArrayQueue<ScheduledWrite> writeQueue = new MpscUnboundedArrayQueue<>(8192);
+   MpscUnboundedVarHandleArrayQueue<ScheduledWrite> writeQueue = new MpscUnboundedVarHandleArrayQueue<>(8192);
 
    // Allows DB Drivers to cache meta data.
    private final Map<Object, Object> metaData = new ConcurrentHashMap<>();

--- a/artemis-journal/pom.xml
+++ b/artemis-journal/pom.xml
@@ -54,7 +54,7 @@
       </dependency>
       <dependency>
          <groupId>org.jctools</groupId>
-         <artifactId>jctools-core</artifactId>
+         <artifactId>jctools-core-jdk11</artifactId>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
@@ -42,7 +42,7 @@ import org.apache.activemq.artemis.utils.critical.CriticalAnalyzer;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
-import org.jctools.queues.MpmcArrayQueue;
+import org.jctools.queues.varhandle.MpmcVarHandleArrayQueue;
 import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 
 public final class AIOSequentialFileFactory extends AbstractSequentialFileFactory {
@@ -115,7 +115,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
          logger.warn("Using journal-max-io 1 isn't a proper use of ASYNCIO journal: consider rise this value or use NIO.");
       }
       final int adjustedMaxIO = Math.max(2, maxIO);
-      callbackPool = PlatformDependent.hasUnsafe() ? new MpmcArrayQueue<>(adjustedMaxIO) : new MpmcAtomicArrayQueue<>(adjustedMaxIO);
+      callbackPool = PlatformDependent.hasUnsafe() ? new MpmcVarHandleArrayQueue<>(adjustedMaxIO) : new MpmcAtomicArrayQueue<>(adjustedMaxIO);
       logger.trace("New AIO File Created");
    }
 

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -418,7 +418,7 @@
          <!--needed to compile transport jar-->
          <dependency>
             <groupId>org.jctools</groupId>
-            <artifactId>jctools-core</artifactId>
+            <artifactId>jctools-core-jdk11</artifactId>
             <version>${jctools.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -418,6 +418,12 @@
          <!--needed to compile transport jar-->
          <dependency>
             <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+            <version>${jctools.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.jctools</groupId>
             <artifactId>jctools-core-jdk11</artifactId>
             <version>${jctools.version}</version>
             <!-- License: Apache 2.0 -->

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -92,7 +92,7 @@
       </dependency>
       <dependency>
          <groupId>org.jctools</groupId>
-         <artifactId>jctools-core</artifactId>
+         <artifactId>jctools-core-jdk11</artifactId>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -124,7 +124,7 @@ import org.apache.activemq.artemis.utils.collections.PriorityLinkedList;
 import org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.apache.activemq.artemis.utils.critical.CriticalComponentImpl;
-import org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.varhandle.MpscUnboundedVarHandleArrayQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +202,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    // Messages will first enter intermediateMessageReferences before they are added to messageReferences. This is to
    // avoid locking the queue on the producer
-   private final MpscUnboundedArrayQueue<MessageReference> intermediateMessageReferences;
+   private final MpscUnboundedVarHandleArrayQueue<MessageReference> intermediateMessageReferences;
 
    // This is where messages are stored
    protected final PriorityLinkedList<MessageReference> messageReferences = new PriorityLinkedListImpl<>(QueueImpl.NUM_PRIORITIES, MessageReferenceImpl.getSequenceComparator());
@@ -457,7 +457,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       this.initialQueueBufferSize = this.cachedAddressSettings.getInitialQueueBufferSize() == null
          ? ActiveMQDefaultConfiguration.INITIAL_QUEUE_BUFFER_SIZE
          : this.cachedAddressSettings.getInitialQueueBufferSize();
-      this.intermediateMessageReferences = new MpscUnboundedArrayQueue<>(initialQueueBufferSize);
+      this.intermediateMessageReferences = new MpscUnboundedVarHandleArrayQueue<>(initialQueueBufferSize);
 
       verifyDisabledConfiguration();
    }

--- a/tests/db-tests/pom.xml
+++ b/tests/db-tests/pom.xml
@@ -129,7 +129,7 @@
       </dependency>
       <dependency>
          <groupId>org.jctools</groupId>
-         <artifactId>jctools-core</artifactId>
+         <artifactId>jctools-core-jdk11</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -98,7 +98,7 @@
       </dependency>
       <dependency>
          <groupId>org.jctools</groupId>
-         <artifactId>jctools-core</artifactId>
+         <artifactId>jctools-core-jdk11</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Artemis currently uses some queues from jctools-core which rely on sun.misc.Unsafe internally. These methods are deprecated in JDK24+, issue a warning at runtime and will be removed in future versions of the JDK. Thus it makes sense to switch to an implementation which does not rely on those methods.

In their latest [release](https://github.com/JCTools/JCTools/releases/tag/v4.0.6) JCTools have started to publish a new artifact, jctools-core-jdk11, which contains alternative Varhandle based implementations which do not use Unsafe. As far as I understand them they are designed to be a drop-in replacement to the existing Unsafe implementations.