### PR TITLE
ARTEMIS-6209 Generate an SBOM for the distribution

### DIFF
--- a/artemis-console/pom.xml
+++ b/artemis-console/pom.xml
@@ -83,6 +83,14 @@
                 <!-- include any other file types you want to filter -->
               </includes>
             </resource>
+            <resource>
+              <filtering>false</filtering>
+              <directory>${project.build.directory}</directory>
+              <targetPath>META-INF/sbom</targetPath>
+              <includes>
+                <include>bom.cdx.json</include>
+              </includes>
+            </resource>
           </webResources>
           <overlays>
             <overlay>
@@ -136,6 +144,22 @@
             </replacement>
           </replacements>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>dev.cyberstamp.maven.assembly.sbom</groupId>
+        <artifactId>assembly-sbom-maven-plugin</artifactId>
+        <version>0.1.0</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/bom.cdx.json</outputFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>

--- a/artemis-console/pom.xml
+++ b/artemis-console/pom.xml
@@ -83,6 +83,14 @@
                 <!-- include any other file types you want to filter -->
               </includes>
             </resource>
+            <resource>
+              <filtering>false</filtering>
+              <directory>${project.build.directory}</directory>
+              <targetPath>META-INF/sbom</targetPath>
+              <includes>
+                <include>bom.cdx.json</include>
+              </includes>
+            </resource>
           </webResources>
           <overlays>
             <overlay>
@@ -136,6 +144,22 @@
             </replacement>
           </replacements>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>dev.cyberstamp.maven.assembly.sbom</groupId>
+        <artifactId>assembly-sbom-maven-plugin</artifactId>
+        <version>${assembly-sbom-version}</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/bom.cdx.json</outputFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -174,6 +174,13 @@
          </plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <dependencies>
+               <dependency>
+                  <groupId>dev.cyberstamp.maven.assembly.sbom</groupId>
+                  <artifactId>assembly-sbom-handler</artifactId>
+                  <version>${assembly-sbom-version}</version>
+               </dependency>
+            </dependencies>
             <executions>
                <execution>
                   <id>bin</id>

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -174,6 +174,13 @@
          </plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <dependencies>
+               <dependency>
+                  <groupId>dev.cyberstamp.maven.assembly.sbom</groupId>
+                  <artifactId>assembly-sbom-handler</artifactId>
+                  <version>0.1.0</version>
+               </dependency>
+            </dependencies>
             <executions>
                <execution>
                   <id>bin</id>

--- a/artemis-distribution/src/main/assembly/bin.xml
+++ b/artemis-distribution/src/main/assembly/bin.xml
@@ -26,6 +26,22 @@
    </formats>
    <includeBaseDirectory>true</includeBaseDirectory>
 
+   <containerDescriptorHandlers>
+      <containerDescriptorHandler>
+         <handlerName>sbom</handlerName>
+         <configuration>
+             <!-- Pritty-print the SBOM JSON, defaults to false
+             <prettyPrint>true</prettyPrint -->
+             <!-- Whether to embed the SBOM in the archive or generate it next to it: embedded - default, external, all
+             <outputMode>all</outputMode -->
+             <!-- Whether to manifest only library components or all the files in a distribution, defaults to false
+             <librariesOnly>true</librariesOnly -->
+             <!-- Whether to attach an external SBOM as a Maven artifact, defaults to false
+             <attach>true</attach -->
+         </configuration>
+      </containerDescriptorHandler>
+   </containerDescriptorHandlers>
+
    <componentDescriptors>
        <componentDescriptor>dep.xml</componentDescriptor>
    </componentDescriptors>

--- a/artemis-distribution/src/main/assembly/dir.xml
+++ b/artemis-distribution/src/main/assembly/dir.xml
@@ -25,6 +25,12 @@
    </formats>
    <includeBaseDirectory>true</includeBaseDirectory>
 
+   <containerDescriptorHandlers>
+      <containerDescriptorHandler>
+         <handlerName>sbom</handlerName>
+      </containerDescriptorHandler>
+   </containerDescriptorHandlers>
+
    <componentDescriptors>
        <componentDescriptor>dep.xml</componentDescriptor>
    </componentDescriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
 
       <activemq-artemis-native-version>2.0.0</activemq-artemis-native-version>
       <artemis-console-version>1.8.0</artemis-console-version>
+      <assembly-sbom-version>0.1.4</assembly-sbom-version>
       <karaf.version>4.4.11</karaf.version>
       <pax.exam.version>4.14.0</pax.exam.version>
       <commons.config.version>2.15.1</commons.config.version>


### PR DESCRIPTION
This PR adds SBOM generation to the Artemis distribution and enables options to distribute it along:
* as a distribution archive entry (embedded);
* as a Maven artifact;
* or both.

The SBOM will be more complete (including the NPM components) when the corresponding change is merged and released as part of artemis-console (https://github.com/apache/artemis-console/pull/219).

Advantages of the SBOM:
* simplified vulnerability scanning (e.g. `grype bom.cdx.json`);
* consolidated license report per component;
* up-to-date accurate component inventory.

The SBOM generator used here is https://github.com/cyberstamp/maven-assembly-sbom

I did some analysis of the generated SBOM accuracy and comparison of the LICENSE report in my other branch, where I have an HTML summary of that https://github.com/aloubyansky/artemis/blob/sbom-support-wip/artemis-distribution/sbom-review.html

I previously demoed this to @brusdev 