### PR TITLE
ARTEMIS-6176 Update to proton-j 0.35.0 and add configuration

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -102,7 +102,7 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
    // delivery-failed flag set true.
    private boolean amqpTreatRejectAsUnmodifiedDeliveryFailed = AmqpSupport.AMQP_TREAT_REJECT_AS_UNMODIFIED_DELIVERY_FAILURE;
 
-   private int initialRemoteMaxFrameSize = 4 * 1024;
+   private int initialRemoteMaxFrameSize = AmqpSupport.INITIAL_REMOTE_MAX_FRAME_SIZE_DEFAULT;
 
    private String[] saslMechanisms = MechanismFinder.getDefaultMechanisms();
 
@@ -127,6 +127,8 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
    private String pubSubPrefix = DestinationUtil.TOPIC_QUALIFIED_PREFIX;
 
    private int maxFrameSize = AmqpSupport.MAX_FRAME_SIZE_DEFAULT;
+
+   private int maxTransfersPerDelivery = AmqpSupport.DEFAULT_MAX_TRANSFERS_PER_DELIVERY;
 
    public ProtonProtocolManager(ProtonProtocolManagerFactory factory, ActiveMQServer server, List<BaseInterceptor> incomingInterceptors, List<BaseInterceptor> outgoingInterceptors) {
       this.factory = factory;
@@ -359,6 +361,14 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    public void setMaxFrameSize(int maxFrameSize) {
       this.maxFrameSize = maxFrameSize;
+   }
+
+   public int getMaxTransfersPerDelivery() {
+      return maxTransfersPerDelivery;
+   }
+
+   public void setMaxTransfersPerDelivery(int maxTransfersPerDelivery) {
+      this.maxTransfersPerDelivery = maxTransfersPerDelivery;
    }
 
    public String[] getSaslMechanisms() {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -215,6 +215,10 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
       transport.setInitialRemoteMaxFrameSize(protocolManager.getInitialRemoteMaxFrameSize());
       transport.setMaxFrameSize(maxFrameSize);
       transport.setOutboundFrameSizeLimit(maxFrameSize);
+      if (protocolManager.getMaxTransfersPerDelivery() > 0) {
+         transport.setMaxTransfersPerDelivery(protocolManager.getMaxTransfersPerDelivery());
+      }
+
       if (saslClientFactory != null) {
          handler.createClientSASL();
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
@@ -98,6 +98,26 @@ public class AmqpSupport {
    static final Symbol FAILOVER_SERVER_LIST = Symbol.valueOf("failover-server-list");
 
    public static final int MAX_FRAME_SIZE_DEFAULT = 128 * 1024;
+   public static final int INITIAL_REMOTE_MAX_FRAME_SIZE_DEFAULT = 4 * 1024;
+
+   /**
+    * Default for the number of allowed transfers for a given incoming delivery. This does govern
+    * the maximum message size to an extent when combined with the maximum frame size.
+    */
+   public static final int DEFAULT_MAX_TRANSFERS_PER_DELIVERY = 65535;
+
+   /**
+    * The default maximum depth the decoder will allow before triggering a decoding error when
+    * the depth is increased during decode of complex types that can nest objects.
+    */
+   public static final int DEFAULT_MAX_DECODE_DEPTH = 32;
+
+   /**
+    * Default for the allowed number of elements that can be decoded when an array encoding is one of
+    * the zero width type (e.g. UINT0). We allow only zero sized zero width array encodings by default
+    * as the this is not generally expected in normal encodings.
+    */
+   public static final int DEFAULT_ZERO_WIDTH_ARRAY_ELEMENT_LIMIT = 0;
 
    // Symbols used in configuration of newly opened links.
    public static final Symbol COPY = Symbol.getSymbol("copy");

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/TLSEncode.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/TLSEncode.java
@@ -16,33 +16,73 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.util;
 
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
 import org.apache.qpid.proton.codec.AMQPDefinedTypes;
 import org.apache.qpid.proton.codec.DecoderImpl;
 import org.apache.qpid.proton.codec.EncoderImpl;
 
 /**
- * This can go away if Proton provides this feature.
+ * Thread local codec support class that manages the Qpid proton Encoder and Decoder types.
  */
 public class TLSEncode {
 
-   // For now Proton requires that we create a decoder to create an encoder
-   private static class EncoderDecoderPair {
-      DecoderImpl decoder = new DecoderImpl();
-      EncoderImpl encoder = new EncoderImpl(decoder);
-      {
+   public static final String MAX_DECODE_DEPTH_PROPERTY = "artemis.amqp.maxDecodeDepth";
+   public static final String ZERO_WIDTH_ARRAY_ELEMENT_LIMIT_PROPERTY = "artemis.amqp.zeroWidthArrayElementLimit";
+
+   public static class EncoderDecoderPair {
+
+      // Static configuration options created once for the broker instance to ensure
+      // all decoders are using the same values at all times during a given run so that
+      // a mix of values cannot exist for incoming messages or for a journal reader etc.
+
+      private static final int MAX_DECODE_DEPTH =
+         Integer.getInteger(MAX_DECODE_DEPTH_PROPERTY, AmqpSupport.DEFAULT_MAX_DECODE_DEPTH);
+      private static final int ZERO_WIDTH_ARRAY_ELEMENT_LIMIT =
+         Integer.getInteger(ZERO_WIDTH_ARRAY_ELEMENT_LIMIT_PROPERTY, AmqpSupport.DEFAULT_ZERO_WIDTH_ARRAY_ELEMENT_LIMIT);
+
+      private final DecoderImpl decoder = new DecoderImpl();
+      private final EncoderImpl encoder = new EncoderImpl(decoder);
+
+      EncoderDecoderPair() {
          AMQPDefinedTypes.registerAllTypes(decoder, encoder);
+      }
+
+      public EncoderImpl getEncoder() {
+         return encoder;
+      }
+
+      public int getMaxDecodeDepth() {
+         return MAX_DECODE_DEPTH;
+      }
+
+      public int getZeroWidthArrayElementLimit() {
+         return ZERO_WIDTH_ARRAY_ELEMENT_LIMIT;
+      }
+
+      public DecoderImpl getDecoder() {
+         final DecoderImpl decoder = this.decoder;
+
+         // Each returned decoder is reset to configured or assigned defaults to ensure a
+         // consistent starting point, the caller can assign new values which we don't want
+         // to be sticky between calls.
+         decoder.setMaxDecodeDepth(MAX_DECODE_DEPTH);
+         decoder.setZeroWidthArrayElementLimit(ZERO_WIDTH_ARRAY_ELEMENT_LIMIT);
+
+         return decoder;
       }
    }
 
    private static final ThreadLocal<EncoderDecoderPair> tlsCodec = ThreadLocal.withInitial(() -> new EncoderDecoderPair());
 
+   public static EncoderDecoderPair getCodec() {
+      return tlsCodec.get();
+   }
+
    public static EncoderImpl getEncoder() {
-      return tlsCodec.get().encoder;
+      return tlsCodec.get().getEncoder();
    }
 
    public static DecoderImpl getDecoder() {
-      return tlsCodec.get().decoder;
+      return tlsCodec.get().getDecoder();
    }
-
-
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContextTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContextTest.java
@@ -49,6 +49,9 @@ public class AMQPConnectionContextTest {
 
       ProtonProtocolManager manager = Mockito.mock(ProtonProtocolManager.class);
       Mockito.when(manager.getServer()).thenReturn(server);
+      Mockito.when(manager.getMaxFrameSize()).thenReturn(AmqpSupport.MAX_FRAME_SIZE_DEFAULT);
+      Mockito.when(manager.getInitialRemoteMaxFrameSize()).thenReturn(AmqpSupport.INITIAL_REMOTE_MAX_FRAME_SIZE_DEFAULT);
+      Mockito.when(manager.getMaxTransfersPerDelivery()).thenReturn(AmqpSupport.DEFAULT_MAX_TRANSFERS_PER_DELIVERY);
 
       EventLoop eventLoop = Mockito.mock(EventLoop.class);
       Channel transportChannel = Mockito.mock(Channel.class);
@@ -85,5 +88,58 @@ public class AMQPConnectionContextTest {
       connectionContext.close(null);
 
       assertEquals(0, scheduledPool.getQueue().size());
+   }
+
+   @Test
+   public void testMaxTransferPerDeliveryAppliedToConnectionContext() throws Exception {
+      ArtemisExecutor executor = Mockito.mock(ArtemisExecutor.class);
+      ExecutorFactory executorFactory = Mockito.mock(ExecutorFactory.class);
+      Mockito.when(executorFactory.getExecutor()).thenReturn(executor);
+
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+      Mockito.when(server.getExecutorFactory()).thenReturn(executorFactory);
+
+      final int expectedMaxTransfersPerDelivery = AmqpSupport.DEFAULT_MAX_TRANSFERS_PER_DELIVERY + 10;
+
+      ProtonProtocolManager manager = Mockito.mock(ProtonProtocolManager.class);
+      Mockito.when(manager.getServer()).thenReturn(server);
+      Mockito.when(manager.getMaxFrameSize()).thenReturn(AmqpSupport.MAX_FRAME_SIZE_DEFAULT);
+      Mockito.when(manager.getInitialRemoteMaxFrameSize()).thenReturn(AmqpSupport.INITIAL_REMOTE_MAX_FRAME_SIZE_DEFAULT);
+      Mockito.when(manager.getMaxTransfersPerDelivery()).thenReturn(expectedMaxTransfersPerDelivery);
+
+      EventLoop eventLoop = Mockito.mock(EventLoop.class);
+      Channel transportChannel = Mockito.mock(Channel.class);
+      Mockito.when(transportChannel.config()).thenReturn(Mockito.mock(ChannelConfig.class));
+      Mockito.when(transportChannel.eventLoop()).thenReturn(eventLoop);
+      Mockito.when(eventLoop.inEventLoop()).thenReturn(true);
+      NettyConnection transportConnection = new NettyConnection(new HashMap<>(), transportChannel, null, false, false);
+
+      Connection connection = Mockito.mock(Connection.class);
+      AMQPConnectionCallback protonSPI = Mockito.mock(AMQPConnectionCallback.class);
+      Mockito.when(protonSPI.getTransportConnection()).thenReturn(transportConnection);
+      Mockito.when(protonSPI.validateConnection(connection, null)).thenReturn(true);
+
+      ScheduledThreadPoolExecutor scheduledPool = new ScheduledThreadPoolExecutor(
+         ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize());
+
+      AMQPConnectionContext connectionContext = new AMQPConnectionContext(
+         manager,
+         protonSPI,
+         null,
+         (int) ActiveMQClient.DEFAULT_CONNECTION_TTL,
+         manager.getMaxFrameSize(),
+         AMQPConstants.Connection.DEFAULT_CHANNEL_MAX,
+         false,
+         scheduledPool,
+         false,
+         null,
+         null,
+         null,
+         null);
+
+      assertEquals(expectedMaxTransfersPerDelivery, connectionContext.getHandler().getTransport().getMaxTransfersPerDelivery());
+
+      connectionContext.onRemoteOpen(connection);
+      connectionContext.close(null);
    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 
       <!-- this is basically for tests -->
       <netty-tcnative-version>2.0.80.Final</netty-tcnative-version>
-      <proton.version>0.34.1</proton.version>
+      <proton.version>0.35.0</proton.version>
       <protonj2.version>1.1.0</protonj2.version>
       <slf4j.version>2.0.18</slf4j.version>
       <log4j.version>2.26.1</log4j.version>

--- a/tests/integration-tests-isolated/src/test/java/org/apache/activemq/artemis/tests/integration/isolated/amqp/AmqpTLSCodecOverridesTest.java
+++ b/tests/integration-tests-isolated/src/test/java/org/apache/activemq/artemis/tests/integration/isolated/amqp/AmqpTLSCodecOverridesTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.isolated.amqp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.EncodingCodes;
+import org.apache.qpid.protonj2.test.driver.ProtonTestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for configuration of the max transfers per delivery option
+ */
+class AmqpTLSCodecOverridesTest extends ActiveMQTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final int maxDecodeDepth = AmqpSupport.DEFAULT_MAX_DECODE_DEPTH + 1;
+   private final int zeroWidthArrayElementLimit = AmqpSupport.DEFAULT_ZERO_WIDTH_ARRAY_ELEMENT_LIMIT + 1;
+
+   @Test
+   @Timeout(20)
+   public void testTLSEncodeAppliesSystemPropertiesForProtonDecodeControls() throws Exception {
+      ActiveMQServer server = createServer(true, createDefaultConfig(true));
+      server.start();
+      server.createQueue(QueueConfiguration.of(getTestMethodName())
+                                           .setRoutingType(RoutingType.ANYCAST)
+                                           .setAddress(getTestMethodName())
+                                           .setAutoCreated(false));
+
+      System.setProperty(TLSEncode.MAX_DECODE_DEPTH_PROPERTY, Integer.toString(maxDecodeDepth));
+      System.setProperty(TLSEncode.ZERO_WIDTH_ARRAY_ELEMENT_LIMIT_PROPERTY, Integer.toString(zeroWidthArrayElementLimit));
+
+      runAfter(() -> {
+         System.clearProperty(TLSEncode.MAX_DECODE_DEPTH_PROPERTY);
+         System.clearProperty(TLSEncode.ZERO_WIDTH_ARRAY_ELEMENT_LIMIT_PROPERTY);
+      });
+
+      assertEquals(maxDecodeDepth, TLSEncode.getCodec().getMaxDecodeDepth());
+      assertEquals(zeroWidthArrayElementLimit, TLSEncode.getCodec().getZeroWidthArrayElementLimit());
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", 61616);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", 61616);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestMethodName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ByteBuffer zeroWidthPayload = createEncodedMessageWithZeroWidthArray(zeroWidthArrayElementLimit); // Should work
+
+         peer.expectDisposition().withState().accepted();
+         peer.remoteTransfer().withHandle(0)
+                              .withDeliveryId(0)
+                              .withDeliveryTag(new byte[] {1})
+                              .withMore(false)
+                              .withMessageFormat(0)
+                              .withPayload(zeroWidthPayload).now();
+
+         final ByteBuffer nestedObjectPayload = createNestedEncodedMessage(maxDecodeDepth); // Should work
+
+         peer.expectDisposition().withState().accepted();
+         peer.remoteTransfer().withHandle(0)
+                              .withDeliveryId(1)
+                              .withDeliveryTag(new byte[] {2})
+                              .withMore(false)
+                              .withMessageFormat(0)
+                              .withPayload(nestedObjectPayload).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.remoteClose().now();
+         peer.close();
+      }
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", 61616);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", 61616);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestMethodName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ByteBuffer zeroWidthPayload = createEncodedMessageWithZeroWidthArray(zeroWidthArrayElementLimit + 1); // Shouldn't work
+
+         peer.expectClose().withError(AmqpError.INTERNAL_ERROR.toString());
+         peer.remoteTransfer().withHandle(0)
+                              .withDeliveryId(0)
+                              .withDeliveryTag(new byte[] {1})
+                              .withMore(false)
+                              .withMessageFormat(0)
+                              .withPayload(zeroWidthPayload).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.remoteClose().now();
+         peer.close();
+      }
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", 61616);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", 61616);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestMethodName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ByteBuffer nestedObjectPayload = createNestedEncodedMessage(maxDecodeDepth + 1); // Shouldn't work
+
+         peer.expectClose().withError(AmqpError.INTERNAL_ERROR.toString());
+         peer.remoteTransfer().withHandle(0)
+                              .withDeliveryId(0)
+                              .withDeliveryTag(new byte[] {1})
+                              .withMore(false)
+                              .withMessageFormat(0)
+                              .withPayload(nestedObjectPayload).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.remoteClose().now();
+         peer.close();
+      }
+   }
+
+   // Must use a message annotations section since the broker won't normally decode
+   // the body section unless doing a conversion later.
+   private ByteBuffer createNestedEncodedMessage(final int depth) {
+      if (depth < 2) {
+         throw new IllegalArgumentException("depth needs to be greater than two to account for Section layers");
+      }
+
+      final EncoderImpl encoder = TLSEncode.getEncoder();
+      final ByteBuffer buffer = ByteBuffer.allocate(128);
+      final List<Object> entry = new ArrayList<>();
+      final Map<Symbol, Object> map = new HashMap<>();
+      final MessageAnnotations value = new MessageAnnotations(map);
+
+      List<Object> current = entry;
+      for (int i = 2; i < depth; ++i) {
+         final List<Object> next = new ArrayList<>();
+
+         current.add(next);
+         current = next;
+      }
+
+      map.put(Symbol.valueOf("a"), entry);
+
+      try {
+         encoder.setByteBuffer(buffer);
+         encoder.writeObject(value);
+      } finally {
+         encoder.setByteBuffer((ByteBuffer) null);
+      }
+
+      return buffer.flip();
+   }
+
+   // Must use a message annotations section since the broker won't normally decode
+   // the body section unless doing a conversion later.
+   protected ByteBuffer createEncodedMessageWithZeroWidthArray(int length) {
+      if (length < 0 || length > 255) {
+         throw new IllegalArgumentException("Length must be within the range of an unsigned byte");
+      }
+
+      final ByteBuffer buffer = ByteBuffer.allocate(16);
+
+      buffer.put((byte) 0); // Described Type Indicator
+      buffer.put(EncodingCodes.SMALLULONG);
+      buffer.put((byte) 0x72); // message annotations descriptor
+      buffer.put(EncodingCodes.MAP8);
+      buffer.put((byte) 8);  // Size
+      buffer.put((byte) 2);  // Count
+      buffer.put(EncodingCodes.SYM8);
+      buffer.put((byte) 1);
+      buffer.put((byte) 65);
+      buffer.put(EncodingCodes.ARRAY8);
+      buffer.put((byte) 2);
+      buffer.put((byte) length);
+      buffer.put(EncodingCodes.BOOLEAN_TRUE);
+
+      return buffer.flip();
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMaxTransfersPerDeliveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMaxTransfersPerDeliveryTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.qpid.proton.amqp.transport.LinkError;
+import org.apache.qpid.protonj2.test.driver.ProtonTestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for configuration of the max transfers per delivery option
+ */
+class AmqpMaxTransfersPerDeliveryTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP";
+   }
+
+   @Override
+   protected void configureAMQPAcceptorParameters(Map<String, Object> params) {
+      params.put("maxTransfersPerDelivery", "3");
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      return createServer(AMQP_PORT, true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testFailureOnViolationOfPerDeliveryTransferLimit() throws Exception {
+      byte[] first = "A".repeat(10).getBytes(StandardCharsets.UTF_8);
+      byte[] second = "B".repeat(10).getBytes(StandardCharsets.UTF_8);
+      byte[] third = "C".repeat(10).getBytes(StandardCharsets.UTF_8);
+      byte[] fourth = "D".repeat(10).getBytes(StandardCharsets.UTF_8);
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withDeliveryTag(new byte[] {0})
+                              .withMore(true)
+                              .withMessageFormat(0)
+                              .withBody().withData(first).also().now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(true)
+                              .withBody().withData(second).also().now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(true)
+                              .withBody().withData(third).also().now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(false)
+                              .withBody().withData(fourth).also().now();
+
+         peer.expectClose().withError(LinkError.TRANSFER_LIMIT_EXCEEDED.toString());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testFailureOnViolationOfPerDeliveryTransferLimitWithEmptyTransfer() throws Exception {
+      byte[] first = "A".repeat(10).getBytes(StandardCharsets.UTF_8);
+      byte[] second = "B".repeat(10).getBytes(StandardCharsets.UTF_8);
+      byte[] third = "C".repeat(10).getBytes(StandardCharsets.UTF_8);
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withDeliveryTag(new byte[] {0})
+                              .withMore(true)
+                              .withMessageFormat(0)
+                              .withBody().withData(first).also().now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(true)
+                              .now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(true)
+                              .withBody().withData(second).also().now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(false)
+                              .withBody().withData(third).also().now();
+
+         peer.expectClose().withError(LinkError.TRANSFER_LIMIT_EXCEEDED.toString());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testFailureOnViolationOfPerDeliveryTransferLimitWithAllEmptyTransfers() throws Exception {
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withDeliveryTag(new byte[] {0})
+                              .withMore(true)
+                              .withMessageFormat(0)
+                              .now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(true)
+                              .now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(true)
+                              .now();
+         peer.remoteTransfer().withDeliveryId(0)
+                              .withMore(false)
+                              .now();
+
+         peer.expectClose().withError(LinkError.TRANSFER_LIMIT_EXCEEDED.toString());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.close();
+      }
+   }
+}


### PR DESCRIPTION
Update to proton-j 0.35.0 and add configuration options to allow control of new proton-j options added as part of that release

Add new option maxTransfersPerDelivery with default of 65535 Add system property configuration to the TLSEncode object to update maxDecodeDepth and zeroWidthArrayElementLimit values for the proton codec in case of a backwards compatible issue a user might face.