### PR TITLE
ARTEMIS-6179 Fix deleteReference/depage deadlock

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2223,7 +2223,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    }
 
    @Override
-   public synchronized boolean deleteReference(final long messageID) throws Exception {
+   public boolean deleteReference(final long messageID) throws Exception {
       return iterQueue("deleteReference", DEFAULT_FLUSH_LIMIT, null, new QueueIterateAction(messageID) {
          @Override
          public boolean actMessage(Transaction tx, MessageReference ref) throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java
@@ -20,12 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.json.JsonArray;
 import org.apache.activemq.artemis.json.JsonNumber;
 import org.apache.activemq.artemis.json.JsonObject;
 import org.apache.activemq.artemis.json.JsonValue;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +52,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -322,6 +327,72 @@ public class ManagementWithPagingServerTest extends ManagementTestBase {
       assertEquals(messages.length, console.copiedMessages);
    }
 
+   /**
+    * Reproduction for ARTEMIS-6179: QueueImpl#deleteReference() is still {@code synchronized} and calls
+    * iterQueue(), which locks depageLock -- while QueueImpl#depage() locks depageLock first and then enters a
+    * synchronized(this) block. Racing QueueControl#removeMessage() (-> deleteReference()) against depaging
+    * (triggered here by the ReceiverThread acking messages) can deadlock the two threads against each other.
+    * This mirrors testMoveMessageWhilstPagingAndConsuming(), which caught the equivalent bug for copyReference()
+    * (ARTEMIS-5376), replacing copyMessage with removeMessage. Detection uses the JVM's own deadlock detector
+    * (ThreadMXBean) instead of a fixed timeout, since a hang here is the failure itself.
+    */
+   @Test
+   public void testRemoveMessageWhilstPagingAndConsuming() throws Exception {
+      final int messagesPerIteration = 2000;
+      final int maxIterations = 20;
+      final long iterationTimeoutMillis = 5000;
+      final long pollIntervalMillis = 20;
+
+      SimpleString address = RandomUtil.randomUUIDSimpleString();
+      SimpleString queue = RandomUtil.randomUUIDSimpleString();
+
+      session1.createQueue(QueueConfiguration.of(queue).setAddress(address));
+
+      QueueControl queueControl = createManagementControl(address, queue);
+
+      ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+      // A single remover is sufficient: QueueControlImpl#removeMessage() is serialized broker-wide through
+      // ActiveMQServerImpl's managementLock, so extra concurrent removers would just contend on that lock
+      // without increasing the odds of racing depage().
+      ManagementRemoveThread remover = new ManagementRemoveThread(queueControl);
+      remover.setDaemon(true);
+      remover.start();
+
+      long[] deadlockedIds = null;
+
+      for (int iteration = 0; iteration < maxIterations; iteration++) {
+         SenderThread sender = new SenderThread(address, messagesPerIteration, 0);
+         ReceiverThread receiver = new ReceiverThread(queue, messagesPerIteration, 0);
+         sender.setDaemon(true);
+         receiver.setDaemon(true);
+
+         sender.start();
+         receiver.start();
+
+         Wait.waitFor(() -> !receiver.isAlive() || threadMXBean.findDeadlockedThreads() != null,
+                      iterationTimeoutMillis, pollIntervalMillis);
+
+         deadlockedIds = threadMXBean.findDeadlockedThreads();
+         if (deadlockedIds != null) {
+            break;
+         }
+      }
+
+      remover.exit();
+      remover.join(iterationTimeoutMillis);
+      assertNull(remover.getError());
+
+      if (deadlockedIds != null) {
+         StringBuilder sb = new StringBuilder("Deadlock detected between removeMessage() and depage():\n");
+         for (long id : deadlockedIds) {
+            ThreadInfo info = threadMXBean.getThreadInfo(id, Integer.MAX_VALUE);
+            sb.append(info).append('\n');
+         }
+         fail(sb.toString());
+      }
+   }
+
    @Override
    @BeforeEach
    public void setUp() throws Exception {
@@ -493,6 +564,38 @@ public class ManagementWithPagingServerTest extends ManagementTestBase {
                if (copied) {
                   copiedMessages++;
                }
+            }
+         } catch (Exception e) {
+            error = e;
+         }
+      }
+
+      public Exception getError() {
+         return error;
+      }
+
+      public void exit() {
+         stop = true;
+      }
+   }
+
+   private class ManagementRemoveThread extends Thread {
+
+      private QueueControl queueControl;
+      private volatile boolean stop = false;
+      private Exception error = null;
+
+      private ManagementRemoveThread(QueueControl queueControl) {
+         this.queueControl = queueControl;
+      }
+
+      @Override
+      public void run() {
+         try {
+            Random random = new Random(System.currentTimeMillis());
+            while (!stop) {
+               long messageID = random.nextInt(5000);
+               queueControl.removeMessage(messageID);
             }
          } catch (Exception e) {
             error = e;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java
@@ -20,16 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.json.JsonArray;
 import org.apache.activemq.artemis.json.JsonNumber;
 import org.apache.activemq.artemis.json.JsonObject;
 import org.apache.activemq.artemis.json.JsonValue;
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +48,6 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -327,72 +322,6 @@ public class ManagementWithPagingServerTest extends ManagementTestBase {
       assertEquals(messages.length, console.copiedMessages);
    }
 
-   /**
-    * Reproduction for ARTEMIS-6179: QueueImpl#deleteReference() is still {@code synchronized} and calls
-    * iterQueue(), which locks depageLock -- while QueueImpl#depage() locks depageLock first and then enters a
-    * synchronized(this) block. Racing QueueControl#removeMessage() (-> deleteReference()) against depaging
-    * (triggered here by the ReceiverThread acking messages) can deadlock the two threads against each other.
-    * This mirrors testMoveMessageWhilstPagingAndConsuming(), which caught the equivalent bug for copyReference()
-    * (ARTEMIS-5376), replacing copyMessage with removeMessage. Detection uses the JVM's own deadlock detector
-    * (ThreadMXBean) instead of a fixed timeout, since a hang here is the failure itself.
-    */
-   @Test
-   public void testRemoveMessageWhilstPagingAndConsuming() throws Exception {
-      final int messagesPerIteration = 2000;
-      final int maxIterations = 20;
-      final long iterationTimeoutMillis = 5000;
-      final long pollIntervalMillis = 20;
-
-      SimpleString address = RandomUtil.randomUUIDSimpleString();
-      SimpleString queue = RandomUtil.randomUUIDSimpleString();
-
-      session1.createQueue(QueueConfiguration.of(queue).setAddress(address));
-
-      QueueControl queueControl = createManagementControl(address, queue);
-
-      ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-
-      // A single remover is sufficient: QueueControlImpl#removeMessage() is serialized broker-wide through
-      // ActiveMQServerImpl's managementLock, so extra concurrent removers would just contend on that lock
-      // without increasing the odds of racing depage().
-      ManagementRemoveThread remover = new ManagementRemoveThread(queueControl);
-      remover.setDaemon(true);
-      remover.start();
-
-      long[] deadlockedIds = null;
-
-      for (int iteration = 0; iteration < maxIterations; iteration++) {
-         SenderThread sender = new SenderThread(address, messagesPerIteration, 0);
-         ReceiverThread receiver = new ReceiverThread(queue, messagesPerIteration, 0);
-         sender.setDaemon(true);
-         receiver.setDaemon(true);
-
-         sender.start();
-         receiver.start();
-
-         Wait.waitFor(() -> !receiver.isAlive() || threadMXBean.findDeadlockedThreads() != null,
-                      iterationTimeoutMillis, pollIntervalMillis);
-
-         deadlockedIds = threadMXBean.findDeadlockedThreads();
-         if (deadlockedIds != null) {
-            break;
-         }
-      }
-
-      remover.exit();
-      remover.join(iterationTimeoutMillis);
-      assertNull(remover.getError());
-
-      if (deadlockedIds != null) {
-         StringBuilder sb = new StringBuilder("Deadlock detected between removeMessage() and depage():\n");
-         for (long id : deadlockedIds) {
-            ThreadInfo info = threadMXBean.getThreadInfo(id, Integer.MAX_VALUE);
-            sb.append(info).append('\n');
-         }
-         fail(sb.toString());
-      }
-   }
-
    @Override
    @BeforeEach
    public void setUp() throws Exception {
@@ -564,38 +493,6 @@ public class ManagementWithPagingServerTest extends ManagementTestBase {
                if (copied) {
                   copiedMessages++;
                }
-            }
-         } catch (Exception e) {
-            error = e;
-         }
-      }
-
-      public Exception getError() {
-         return error;
-      }
-
-      public void exit() {
-         stop = true;
-      }
-   }
-
-   private class ManagementRemoveThread extends Thread {
-
-      private QueueControl queueControl;
-      private volatile boolean stop = false;
-      private Exception error = null;
-
-      private ManagementRemoveThread(QueueControl queueControl) {
-         this.queueControl = queueControl;
-      }
-
-      @Override
-      public void run() {
-         try {
-            Random random = new Random(System.currentTimeMillis());
-            while (!stop) {
-               long messageID = random.nextInt(5000);
-               queueControl.removeMessage(messageID);
             }
          } catch (Exception e) {
             error = e;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-6179

`QueueImpl#deleteReference()` is `synchronized` and calls `iterQueue()`, which blocks on `depageLock.lock()`. `depage()` does the reverse: it takes `depageLock` first (via `tryLock()`), then needs to enter `synchronized(this)`. Two threads acquiring the same two locks in opposite order deadlock as soon as they interleave: a `removeMessage()` call holds the object monitor and blocks on `depageLock`, while `depage()` holds `depageLock` and blocks on the monitor. Neither ever releases.

This is the same bug class already fixed for `copyReference()` in [ARTEMIS-5376](https://issues.apache.org/jira/browse/ARTEMIS-5376) (apache/artemis@30c8fc7b10555478dfe6f912b38f312e3a39b165). `deleteReference()` wasn't touched by that fix because it didn't call `iterQueue()` yet at the time — it was moved onto `iterQueue()` two weeks later and kept `synchronized`, reintroducing the same bug.

## The fix

Drop `synchronized` from `deleteReference()`. `iterQueue()` already synchronizes internally via `depageLock`, so the outer lock is redundant and is exactly what causes the reversed order above.

Checked this doesn't introduce a new race: `deleteReference()`'s callback (`incDelivering()` + `acknowledge()`) now runs in the exact synchronization context that `moveReference()` and `sendMessageToDeadLetterAddress()` already use unsynchronized since ARTEMIS-5376, calling the same underlying `acknowledge()`/`move()` machinery.

## Testing

Verified with a dedicated reproduction test ([testRemoveMessageWhilstPagingAndConsuming](https://github.com/apache/artemis/blob/5bc5d371f88c83bd2adaeac8816a10fe790525bb/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java#L330-L394), racing `removeMessage()` against `depage()` while consuming) that reliably deadlocks without this change and passes cleanly with it, plus the existing `QueueControlTest`, `QueueControlUsingCoreTest`, `ManagementWithPagingServerTest`, and `LVQTest` suites, all green. The reproduction test is in the first commit on this branch and removed again in the third, since it's a probabilistic race rather than a deterministic test and isn't suited to the permanent suite.

