### PR TITLE
ARTEMIS-6004 Add clientFailoverAdvertisingEnabled configuration to not send failover server list info to AMQP clients

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -150,6 +150,8 @@ public class TransportConstants {
 
    public static final String TRUST_MANAGER_FACTORY_PLUGIN_PROP_NAME = "trustManagerFactoryPlugin";
 
+   public static final String CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME = "clientFailoverAdvertisingEnabled";
+
    public static final String NETTY_VERSION;
 
    /**
@@ -569,6 +571,7 @@ public class TransportConstants {
       allowableConnectorKeys.add(TransportConstants.CRL_PATH_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.CRC_OPTIONS_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.OCSP_RESPONDER_URL_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME);
 
       ALLOWABLE_CONNECTOR_KEYS = Collections.unmodifiableSet(allowableConnectorKeys);
 

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/tests/uri/ConnectorTransportConfigurationParserURITest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/tests/uri/ConnectorTransportConfigurationParserURITest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.List;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.uri.ConnectorTransportConfigurationParser;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -73,5 +74,21 @@ public class ConnectorTransportConfigurationParserURITest {
       assertEquals("backupB3", objects.get(2).getName());
       assertEquals("backupB", objects.get(2).getParams().get("host"));
       assertEquals("3", objects.get(2).getParams().get("port"));
+   }
+
+   @Test
+   public void testParseClientFailoverAdvertisingEnabled() throws Exception {
+      ConnectorTransportConfigurationParser parser = new ConnectorTransportConfigurationParser(false);
+
+      URI transportURI =
+         parser.expandURI("tcp://backup:61617?clientFailoverAdvertisingEnabled=false");
+
+      List<TransportConfiguration> objects = parser.newObject(transportURI, "backup");
+
+      assertEquals(1, objects.size());
+      assertEquals(
+         "false",
+         objects.get(0).getParams().get(
+            TransportConstants.CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME));
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
@@ -27,10 +27,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 import org.apache.activemq.artemis.core.client.impl.TopologyMemberImpl;
 import org.apache.activemq.artemis.core.remoting.CloseListener;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.cluster.ClusterManager;
@@ -49,12 +51,14 @@ import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.remoting.ReadyListener;
+import org.apache.activemq.artemis.utils.ConfigurationHelper;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.lang.invoke.MethodHandles;
 
 import io.netty.buffer.ByteBuf;
@@ -191,7 +195,7 @@ public class AMQPConnectionCallback implements FailureListener, CloseListener {
    }
 
    public void sendSASLSupported() {
-      connection.write(ActiveMQBuffers.wrappedBuffer(new byte[]{'A', 'M', 'Q', 'P', 3, 1, 0, 0}));
+      connection.write(ActiveMQBuffers.wrappedBuffer(new byte[] {'A', 'M', 'Q', 'P', 3, 1, 0, 0}));
    }
 
    public boolean validateConnection(org.apache.qpid.proton.engine.Connection connection, SASLResult saslResult) {
@@ -266,7 +270,14 @@ public class AMQPConnectionCallback implements FailureListener, CloseListener {
       if (clusterConnection != null) {
          TopologyMemberImpl member = clusterConnection.getTopology().getMember(server.getNodeID().toString());
          if (member != null) {
-            return member.toBackupURI();
+            TransportConfiguration backupConnector = member.getBackup();
+            if (backupConnector == null) {
+               return null;
+            }
+            boolean clientFailoverAdvertisingEnabled = ConfigurationHelper.getBooleanProperty(TransportConstants.CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME, true, backupConnector.getCombinedParams());
+            if (clientFailoverAdvertisingEnabled) {
+               return member.toBackupURI();
+            }
          }
       }
       return null;

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallbackTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallbackTest.java
@@ -23,10 +23,18 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.client.impl.Topology;
+import org.apache.activemq.artemis.core.client.impl.TopologyMemberImpl;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnection;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.security.SecurityStore;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
+import org.apache.activemq.artemis.core.server.cluster.ClusterManager;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.protocol.amqp.sasl.AnonymousServerSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.GSSAPIServerSASL;
@@ -35,6 +43,10 @@ import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AMQPConnectionCallbackTest {
 
@@ -92,5 +104,123 @@ public class AMQPConnectionCallbackTest {
       // Verify result and expected args are passed
       assertFalse(callback.isSupportsAnonymous());
       Mockito.verify(securityStore).authenticate(Mockito.any(), Mockito.any(), Mockito.same(connectionDelegate));
+   }
+
+   @Test
+   public void testGetFailoverListFailoverEnabled() throws Exception {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      TransportConfiguration backup = createBackupTransportConfiguration();
+      backup.getParams().put(TransportConstants.CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME, true);
+
+      AMQPConnectionCallback callback = createCallback(server, backup);
+
+      URI failoverList = callback.getFailoverList();
+
+      assertNotNull(failoverList);
+      assertEquals("tcp", failoverList.getScheme());
+      assertEquals("backup", failoverList.getHost());
+      assertEquals(61617, failoverList.getPort());
+      assertEquals("sslEnabled=false", failoverList.getQuery());
+   }
+
+   @Test
+   public void testGetFailoverListFailoverDisabled() throws Exception {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      TransportConfiguration backup = createBackupTransportConfiguration();
+      backup.getParams().put(TransportConstants.CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME, false);
+
+      AMQPConnectionCallback callback = createCallback(server, backup);
+
+      assertNull(callback.getFailoverList());
+   }
+
+   @Test
+   public void testGetFailoverListFailoverEnabledByDefault() throws Exception {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      TransportConfiguration backup = createBackupTransportConfiguration();
+
+      // CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME is intentionally not set.
+      // The default value is true.
+      AMQPConnectionCallback callback = createCallback(server, backup);
+
+      URI failoverList = callback.getFailoverList();
+
+      assertNotNull(failoverList);
+      assertEquals("tcp", failoverList.getScheme());
+      assertEquals("backup", failoverList.getHost());
+      assertEquals(61617, failoverList.getPort());
+      assertEquals("sslEnabled=false", failoverList.getQuery());
+   }
+
+   @Test
+   public void testGetFailoverListIncludesSslEnabled() throws Exception {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      TransportConfiguration backup = createBackupTransportConfiguration();
+      backup.getParams().put(
+         TransportConstants.SSL_ENABLED_PROP_NAME,
+         true);
+      backup.getParams().put(
+         TransportConstants.CLIENT_FAILOVER_ADVERTISING_ENABLED_PROP_NAME,
+         true);
+
+      AMQPConnectionCallback callback = createCallback(server, backup);
+
+      URI failoverList = callback.getFailoverList();
+
+      assertNotNull(failoverList);
+      assertEquals("tcp", failoverList.getScheme());
+      assertEquals("backup", failoverList.getHost());
+      assertEquals(61617, failoverList.getPort());
+      assertEquals("sslEnabled=true", failoverList.getQuery());
+   }
+
+   private TransportConfiguration createBackupTransportConfiguration() {
+      Map<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.HOST_PROP_NAME, "backup");
+      params.put(TransportConstants.PORT_PROP_NAME, 61617);
+
+      return new TransportConfiguration(
+         NettyConnectorFactory.class.getName(),
+         params);
+   }
+
+
+   private AMQPConnectionCallback createCallback(
+      ActiveMQServer server,
+      TransportConfiguration backup) throws Exception {
+
+      String nodeId = "test-node";
+
+      Mockito.when(server.getNodeID()).thenReturn(SimpleString.of(nodeId));
+
+      ClusterManager clusterManager = Mockito.mock(ClusterManager.class);
+      ClusterConnection clusterConnection = Mockito.mock(ClusterConnection.class);
+      Topology topology = Mockito.mock(Topology.class);
+
+      Mockito.when(server.getClusterManager()).thenReturn(clusterManager);
+      Mockito.when(clusterManager.getDefaultConnection(null)).thenReturn(clusterConnection);
+      Mockito.when(clusterConnection.getTopology()).thenReturn(topology);
+
+      TopologyMemberImpl member = new TopologyMemberImpl(
+         nodeId,
+         null,
+         null,
+         null,
+         backup);
+
+      Mockito.when(topology.getMember(nodeId)).thenReturn(member);
+
+      ProtonProtocolManager protocolManager = Mockito.mock(ProtonProtocolManager.class);
+      Mockito.when(protocolManager.getServer()).thenReturn(server);
+
+      return new AMQPConnectionCallback(
+         protocolManager,
+         null,
+         null,
+         server);
    }
 }

--- a/docs/user-manual/configuring-transports.adoc
+++ b/docs/user-manual/configuring-transports.adoc
@@ -491,6 +491,11 @@ This value takes precedence of all other SSL parameters which apply to the trust
 +
 Any plugin specified will need to be placed on the xref:using-server.adoc#adding-runtime-dependencies[broker's classpath].
 
+clientFailoverAdvertisingEnabled::
+When used on a `connector` determines whether the connector is advertised to clients as a failover connector.
+Valid values are `true` or `false`.
+Default is `true`.
+
 ==== Configuring an SSLContextFactory
 
 If you use `JDK` as SSL provider (the default), you can configure which SSLContextFactory to use.


### PR DESCRIPTION
## Description

Add a `clientFailoverAdvertisingEnabled` connector property to control whether a backup connector is advertised to clients as part of the AMQP failover topology.

Currently, Artemis can advertise the backup connector from the broker's internal cluster topology to AMQP clients. This can cause clients using different internal and external DNS names or ports to receive an unreachable failover endpoint.

For example, an external Qpid JMS client may initially connect using:

```text
amqp://primary.example.com:5672
```

but receive the internal backup connector from the broker topology:

```text
amqp://backup.internal:61616
```

The client can then attempt to use the advertised endpoint instead of the endpoint configured by the client.

This is the scenario described in [ARTEMIS-6004](https://issues.apache.org/jira/browse/ARTEMIS-6004).

### Changes

- Add the `clientFailoverAdvertisingEnabled` connector property.
- Default the property to `true` to preserve existing behavior.
- When set to `false`, the backup connector is not included in the AMQP failover information advertised to clients.
- The connector remains available for internal broker/cluster use; this change only controls client failover advertisement.
- Add unit tests covering:
  - failover advertising enabled
  - failover advertising disabled
  - default behavior
  - SSL-enabled failover URIs

### Testing

The change was tested with a Java Qpid JMS client using an Artemis HA live/backup configuration where the broker's internal cluster topology uses different hostnames/ports from those exposed to external clients.

With:

```text
clientFailoverAdvertisingEnabled=false
```

the broker no longer advertises the internal backup connector to the AMQP client.

As a result, external clients **no longer need to configure**:

```text
failover.amqpOpenServerListAction=IGNORE
```

to prevent Qpid JMS from replacing their configured failover endpoints with the broker-provided topology.

This provides a broker-side solution for clients that cannot be configured with `failover.amqpOpenServerListAction=IGNORE`.
