### PR TITLE
ARTEMIS-6201 Consumer.close on a FQQN could remove the queue

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -952,10 +952,11 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                } else {
                   queueName = SimpleString.of(UUID.randomUUID().toString());
                   createTemporaryQueue(dest, RoutingType.MULTICAST, queueName, coreFilterString, response);
+                  // Only temporary queues are auto-deleted; FQQN queues are not.
+                  autoDeleteQueueName = queueName;
                }
 
                consumer = createClientConsumer(dest, queueName, coreFilterString);
-               autoDeleteQueueName = queueName;
             } else {
                // Durable sub
                if (durability != ConsumerDurability.DURABLE) {

--- a/tests/compatibility-tests/src/main/resources/multicastFQQNTest/multicastFQQNConsumer.groovy
+++ b/tests/compatibility-tests/src/main/resources/multicastFQQNTest/multicastFQQNConsumer.groovy
@@ -1,0 +1,50 @@
+package multicastTest
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory
+import org.apache.activemq.artemis.jms.client.ActiveMQConnection
+import org.apache.activemq.artemis.tests.compatibility.GroovyRun
+
+import javax.jms.*
+
+ActiveMQConnectionFactory consumerFactory = new ActiveMQConnectionFactory("tcp://localhost:61616")
+Connection connection = consumerFactory.createConnection()
+connection.start()
+
+Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+
+Destination topicDest = session.createTopic("myAddress")
+MessageProducer producer = session.createProducer(topicDest)
+String textBody = "multicast compatibility test message"
+producer.send(session.createTextMessage(textBody))
+producer.close()
+
+Destination queueDest = session.createQueue("myAddress::myQueue")
+MessageConsumer consumer = session.createConsumer(queueDest)
+TextMessage message = (TextMessage) consumer.receive(5000)
+GroovyRun.assertNotNull(message)
+GroovyRun.assertEquals(textBody, message.getText())
+println("Received Message :: " + message.getText())
+consumer.close()
+
+println(">> Consumer Closed")
+
+((ActiveMQConnection) connection).getSessionFactory().getConnection().destroy()
+println(">> END >>")
+connection.close()

--- a/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/MulticastAndFQQNTest.java
+++ b/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/MulticastAndFQQNTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.compatibility;
+
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.ARTEMIS_2_44_0;
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.SNAPSHOT;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.server.JournalType;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.compatibility.base.ClasspathBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MulticastAndFQQNTest extends ClasspathBase {
+
+   private ActiveMQServer server;
+
+   @BeforeEach
+   public void setUp() throws Exception {
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.setJournalType(JournalType.NIO);
+      configuration.addAcceptorConfiguration("artemis", "tcp://0.0.0.0:61616");
+      configuration.setSecurityEnabled(false);
+      configuration.setPersistenceEnabled(false);
+
+      AddressSettings addressSettings = new AddressSettings();
+      addressSettings.setRedistributionDelay(0);
+      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      addressSettings.setAutoCreateAddresses(false);
+      addressSettings.setAutoDeleteAddresses(false);
+      addressSettings.setAutoCreateQueues(false);
+      addressSettings.setAutoDeleteQueues(false);
+
+      configuration.addAddressSetting("myAddress", addressSettings);
+
+      QueueConfiguration queueConfig = QueueConfiguration.of("myQueue").setAddress("myAddress").setRoutingType(RoutingType.MULTICAST).setDurable(true);
+
+      List<QueueConfiguration> queueConfigs = new ArrayList<>();
+      queueConfigs.add(queueConfig);
+
+      Set<String> routingTypes = new HashSet<>();
+      routingTypes.add(RoutingType.MULTICAST.toString());
+
+      CoreAddressConfiguration addressConfig = new CoreAddressConfiguration();
+      addressConfig.setName("myAddress");
+      addressConfig.setQueueConfigs(queueConfigs);
+      addressConfig.setRoutingTypes(routingTypes);
+
+      configuration.addAddressConfiguration(addressConfig);
+
+      server = ActiveMQServers.newActiveMQServer(configuration, false);
+      server.start();
+   }
+
+   @AfterEach
+   public void tearDown() throws Exception {
+      if (server != null) {
+         server.stop();
+      }
+   }
+
+   private void testVersion(String version) throws Throwable {
+      assertNotNull(server.locateQueue("myQueue"));
+
+      ClassLoader clientClassloader = getClasspath(version, false);
+      clearGroovy(clientClassloader);
+      evaluate(clientClassloader, "multicastFQQNTest/multicastFQQNConsumer.groovy");
+
+      assertNotNull(server.locateQueue("myQueue"));
+   }
+
+   @Test
+   public void testMultiCastFQQN_SNAPSHOT() throws Throwable {
+      testVersion(SNAPSHOT);
+   }
+
+   @Test
+   public void testMultiCastFQQN_2_44_0() throws Throwable {
+      testVersion(ARTEMIS_2_44_0);
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FullQualifiedQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FullQualifiedQueueTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
 import java.lang.invoke.MethodHandles;
 
 import org.apache.activemq.artemis.api.core.ActiveMQNonExistentQueueException;
@@ -30,7 +37,9 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.apache.activemq.artemis.utils.Wait;
@@ -315,5 +324,49 @@ public class FullQualifiedQueueTest extends ActiveMQTestBase {
       Wait.assertEquals(useProperty ? 1L : 0L, () -> server.getAddressInfo(anycastAddress).getRoutedMessageCount(), 2000, 100);
       Wait.assertEquals(useProperty ? 0L : 1L, () -> server.getAddressInfo(anycastAddress).getUnRoutedMessageCount(), 2000, 100);
       Wait.assertEquals(useProperty ? 1L : 0L, () -> server.locateQueue(anycastQ1).getMessageCount(), 2000, 100);
+   }
+
+   @Test
+   public void testMulticastFQQN_AMQP() throws Exception {
+      testMulticastFQQN("AMQP");
+   }
+
+   @Test
+   public void testMulticastFQQN_CORE() throws Exception {
+      testMulticastFQQN("CORE");
+   }
+
+   @Test
+   public void testMulticastFQQN_OpenWire() throws Exception {
+      testMulticastFQQN("OPENWIRE");
+   }
+
+   private void testMulticastFQQN(String protocol) throws Exception {
+      final String topicName = "topic" + RandomUtil.randomUUIDString();
+      final String queueName = "queue" + RandomUtil.randomUUIDString();
+      final String fqqn = topicName + "::" + queueName;
+
+      server.addAddressInfo(new AddressInfo(topicName).addRoutingType(RoutingType.ANYCAST));
+      server.createQueue(QueueConfiguration.of(queueName).setAddress(topicName).setRoutingType(RoutingType.MULTICAST).setDurable(true));
+
+      assertNotNull(server.locateQueue(queueName));
+
+      ConnectionFactory cf = CFUtil.createConnectionFactory(protocol, "tcp://localhost:61616");
+
+      try (Connection connection = cf.createConnection()) {
+         connection.start();
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         MessageProducer producer = session.createProducer(session.createTopic(topicName));
+         String text = RandomUtil.randomAlphaNumericString(100);
+         producer.send(session.createTextMessage(text));
+         Destination dest = session.createTopic(fqqn);
+         MessageConsumer consumer = session.createConsumer(dest);
+         TextMessage received = (TextMessage) consumer.receive(5000);
+         assertNotNull(received);
+         assertEquals(text, received.getText());
+         consumer.close();
+      }
+
+      assertNotNull(server.locateQueue(queueName));
    }
 }


### PR DESCRIPTION
If you created a consumer on Core Client, using a FQQN, the inner queue could be removed if permissions allow it