### PR TITLE
ARTEMIS-6199 Fix race in WildcardAddressManager

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -251,7 +251,7 @@ public class SimpleAddressManager implements AddressManager {
          final SimpleString bindableQueueName = CompositeAddress.extractQueueName(bindableName);
          final Binding binding = bindings.removeBindingByUniqueName(bindableQueueName);
          if (binding == null) {
-            throw new IllegalStateException("Cannot find binding " + bindableName);
+            throw new IllegalStateException("Cannot find binding " + bindableName + " on " + realAddress);
          } else {
             if (binding instanceof LocalQueueBinding) {
                localBindingsMap.remove(binding.getID());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.postoffice.BindingsFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.core.transaction.Transaction;
@@ -34,6 +35,11 @@ import org.apache.activemq.artemis.utils.CompositeAddress;
 public class WildcardAddressManager extends SimpleAddressManager {
 
    private final AddressMap<Bindings> addressMap = new AddressMap<>(wildcardConfiguration.getAnyWordsString(), wildcardConfiguration.getSingleWordString(), wildcardConfiguration.getDelimiter());
+
+   /**
+    * Guards consistency between {@link #addressMap} and {@link #mappings} when adding or removing bindings for wildcard addresses
+    */
+   private final Object addressMapLock = new Object();
 
    public WildcardAddressManager(final BindingsFactory bindingsFactory,
                                  final WildcardConfiguration wildcardConfiguration,
@@ -50,32 +56,36 @@ public class WildcardAddressManager extends SimpleAddressManager {
          throw ActiveMQMessageBundle.BUNDLE.wildcardOnProducerNotSupported(String.valueOf(address));
       }
 
+      // initial, unsynchronized check for bindings; optimized for the normal case (i.e., existing Bindings)
       Bindings bindings = super.getBindingsForRoutingAddress(address);
 
       if (bindings == null) {
+         synchronized (addressMapLock) {
+            // subsequent, synchronized check for bindings; only used when creating a new Bindings
+            bindings = super.getBindingsForRoutingAddress(address);
+            if (bindings == null) {
+               final Bindings[] lazyCreateResult = new Bindings[1];
 
-         final Bindings[] lazyCreateResult = new Bindings[1];
-
-         addressMap.visitMatchingWildcards(address, new AddressMapVisitor<>() {
-
-            Bindings newBindings = null;
-            @Override
-            public void visit(Bindings matchingBindings) throws Exception {
-               if (newBindings == null) {
-                  newBindings = addMappingsInternal(address, matchingBindings.getBindings());
-                  lazyCreateResult[0] = newBindings;
-               } else {
-                  for (Binding binding : matchingBindings.getBindings()) {
-                     newBindings.addBinding(binding);
+               addressMap.visitMatchingWildcards(address, new AddressMapVisitor<>() {
+                  Bindings newBindings = null;
+                  @Override
+                  public void visit(Bindings matchingBindings) throws Exception {
+                     if (newBindings == null) {
+                        newBindings = addMappingsInternal(address, matchingBindings.getBindings());
+                        lazyCreateResult[0] = newBindings;
+                     } else {
+                        for (Binding binding : matchingBindings.getBindings()) {
+                           newBindings.addBinding(binding);
+                        }
+                     }
                   }
+               });
+
+               bindings = lazyCreateResult[0];
+               if (bindings != null) {
+                  addressMap.put(address, bindings);
                }
             }
-         });
-
-         bindings = lazyCreateResult[0];
-         if (bindings != null) {
-            // record such that any new wildcard bindings can join
-            addressMap.put(address, bindings);
          }
       }
       return bindings;
@@ -91,45 +101,56 @@ public class WildcardAddressManager extends SimpleAddressManager {
     */
    @Override
    public boolean addBinding(final Binding binding) throws Exception {
-      final boolean bindingsForANewAddress = super.addBinding(binding);
-      final SimpleString address = binding.getAddress();
-      final Bindings bindingsForRoutingAddress = mappings.get(binding.getAddress());
+      synchronized (addressMapLock) {
+         final boolean bindingsForANewAddress = super.addBinding(binding);
+         final SimpleString address = binding.getAddress();
+         final Bindings bindingsForRoutingAddress = mappings.get(binding.getAddress());
 
-      if (wildcardConfiguration.isWild(address)) {
+         if (wildcardConfiguration.isWild(address)) {
 
-         addressMap.visitMatching(address, bindings -> {
-            // this wildcard binding needs to be added to matching addresses
-            bindings.addBinding(binding);
-         });
+            addressMap.visitMatching(address, bindings -> {
+               // this wildcard binding needs to be added to matching addresses
+               bindings.addBinding(binding);
+            });
 
-      } else if (bindingsForANewAddress) {
-         // existing wildcards may match this new simple address
-         addressMap.visitMatchingWildcards(address, bindings -> {
-            // apply existing bindings from matching wildcards
-            for (Binding toAdd : bindings.getBindings()) {
-               bindingsForRoutingAddress.addBinding(toAdd);
-            }
-         });
+         } else if (bindingsForANewAddress) {
+            // existing wildcards may match this new simple address
+            addressMap.visitMatchingWildcards(address, bindings -> {
+               // apply existing bindings from matching wildcards
+               for (Binding toAdd : bindings.getBindings()) {
+                  bindingsForRoutingAddress.addBinding(toAdd);
+               }
+            });
+         }
+
+         if (bindingsForANewAddress) {
+            addressMap.put(address, bindingsForRoutingAddress);
+         }
+         return bindingsForANewAddress;
       }
-
-      if (bindingsForANewAddress) {
-         addressMap.put(address, bindingsForRoutingAddress);
-      }
-      return bindingsForANewAddress;
    }
 
    @Override
    public Binding removeBinding(final SimpleString uniqueName, Transaction tx) throws Exception {
-      Binding binding = super.removeBinding(uniqueName, tx);
-      if (binding != null) {
-         SimpleString address = binding.getAddress();
-         if (wildcardConfiguration.isWild(address)) {
-
-            addressMap.visitMatching(address, bindings -> removeBindingInternal(bindings.getName(), uniqueName));
-
+      synchronized (addressMapLock) {
+         Binding binding = super.removeBinding(uniqueName, tx);
+         if (binding != null) {
+            SimpleString address = binding.getAddress();
+            if (wildcardConfiguration.isWild(address)) {
+               addressMap.visitMatching(address, bindings -> {
+                  try {
+                     removeBindingInternal(bindings.getName(), uniqueName);
+                  } catch (IllegalStateException e) {
+                     // The addressMapLock should prevent this IllegalStateException, but we explicitly catch it here
+                     // for additional safety since it would abort the visitor traversal and skip cleanup of remaining
+                     // addresses, leaking their entries in mappings and addressMap.
+                     ActiveMQServerLogger.LOGGER.failedToRemoveBindingDuringWildcardCleanup(uniqueName.toString(), bindings.getName().toString(), e);
+                  }
+               });
+            }
          }
+         return binding;
       }
-      return binding;
    }
 
    @Override
@@ -139,8 +160,10 @@ public class WildcardAddressManager extends SimpleAddressManager {
 
    @Override
    public void clear() {
-      super.clear();
-      addressMap.reset();
+      synchronized (addressMapLock) {
+         super.clear();
+         addressMap.reset();
+      }
    }
 
    public AddressMap<Bindings> getAddressMap() {
@@ -149,8 +172,10 @@ public class WildcardAddressManager extends SimpleAddressManager {
 
    @Override
    public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
-      SimpleString realAddress = CompositeAddress.extractAddressName(address);
-      addressMap.remove(realAddress, super.getBindingsForRoutingAddress(realAddress));
-      return super.removeAddressInfo(address);
+      synchronized (addressMapLock) {
+         SimpleString realAddress = CompositeAddress.extractAddressName(address);
+         addressMap.remove(realAddress, super.getBindingsForRoutingAddress(realAddress));
+         return super.removeAddressInfo(address);
+      }
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1556,4 +1556,7 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 224166, value = "Server is stopping. Unable to delete unreferenced message with id={}.", level = LogMessage.Level.WARN)
    void unableToDeleteMessageDuringShutdown(long messageId);
+
+   @LogMessage(id = 224167, value = "Failed to remove binding {} from address {} during wildcard address cleanup", level = LogMessage.Level.WARN)
+   void failedToRemoveBindingDuringWildcardCleanup(String binding, String address, Exception e);
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/WildCardRoutingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/WildCardRoutingTest.java
@@ -17,6 +17,12 @@
 package org.apache.activemq.artemis.tests.integration.client;
 
 import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -33,6 +39,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.Wait;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -786,6 +793,64 @@ public class WildCardRoutingTest extends ActiveMQTestBase {
       }
    }
 
+
+   /**
+    * Exercises the race between message routing (getBindingsForRoutingAddress, no PostOffice lock) and wildcard queue
+    * create/delete (addBinding/removeBinding, under the PostOffice lock).
+    */
+   @Test
+   public void testConcurrentWildcardBindingChangesDuringRouting() throws Exception {
+      SimpleString wildcardAddress = SimpleString.of("test.#");
+      server.addAddressInfo(new AddressInfo(wildcardAddress, RoutingType.MULTICAST));
+
+      AtomicReference<Throwable> error = new AtomicReference<>();
+      AtomicBoolean running = new AtomicBoolean(true);
+      AtomicInteger addressCounter = new AtomicInteger();
+
+      int bindingThreads = 4;
+      int producerThreads = 8;
+      ExecutorService executor = Executors.newFixedThreadPool(bindingThreads + producerThreads);
+      runAfter(executor::shutdownNow);
+
+      for (int i = 0; i < bindingThreads; i++) {
+         final int id = i;
+         ClientSession bindingSession = addClientSession(sf.createSession(false, true, true));
+         executor.submit(() -> {
+            try {
+               for (int j = 0; running.get() && error.get() == null; j++) {
+                  String queueName = "wc-" + id + "-" + j;
+                  bindingSession.createQueue(QueueConfiguration.of(queueName).setAddress(wildcardAddress).setDurable(false).setAutoDelete(false));
+                  bindingSession.deleteQueue(queueName);
+               }
+            } catch (Throwable t) {
+               error.set(t);
+               running.set(false);
+            }
+         });
+      }
+
+      for (int i = 0; i < producerThreads; i++) {
+         ClientSession producerSession = addClientSession(sf.createSession(false, true, true));
+         executor.submit(() -> {
+            try (ClientProducer producer = producerSession.createProducer()) {
+               while (running.get() && error.get() == null) {
+                  SimpleString address = SimpleString.of("test.addr." + addressCounter.incrementAndGet());
+                  producer.send(address, producerSession.createMessage(false));
+               }
+            } catch (Throwable t) {
+               error.set(t);
+               running.set(false);
+            }
+         });
+      }
+
+      Wait.waitFor(() -> error.get() != null, 10_000);
+      running.set(false);
+
+      executor.shutdown();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS), "finished on time");
+      assertNull(error.get(), "no exceptions");
+   }
 
    @Override
    @BeforeEach

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -365,6 +365,46 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
 
    }
 
+   /**
+    * This test simulates the end state of a race by manually removing a binding from the lazily-created Bindings, then
+    * verifies that removeBinding handles the missing binding without leaking entries in mappings/addressMap.
+    */
+   @Test
+   public void testRemoveWildcardBindingAfterConcurrentGetBindingsForRoutingAddress() throws Exception {
+      final String permanent = "permanent";
+      final String temporary = "temporary";
+      final String myAddress = "myAddress.";
+
+      WildcardAddressManager ad = getTestWildcardAddressManager();
+
+      // Two wildcard bindings that both match "myAddress.foo" and "myAddress.bar"
+      ad.addBinding(new BindingFake("#", permanent));
+      ad.addBinding(new BindingFake(myAddress + "#", temporary));
+
+      // Lazily create Bindings for two addresses; both copy the wildcard bindings
+      Bindings fooBindings = ad.getBindingsForRoutingAddress(SimpleString.of(myAddress + "foo"));
+      Bindings barBindings = ad.getBindingsForRoutingAddress(SimpleString.of(myAddress + "bar"));
+      assertEquals(2, fooBindings.getBindings().size());
+      assertEquals(2, barBindings.getBindings().size());
+
+      // Simulate the race on one address: the "temporary" binding was never copied
+      fooBindings.removeBindingByUniqueName(SimpleString.of(temporary));
+      assertEquals(1, fooBindings.getBindings().size());
+
+      // removeBinding must handle the missing binding on "myAddress.foo" without aborting the visitor traversal. If the
+      // ISE is not caught, the visitor traversal will short-circuit and skip the cleanup of "myAddress.bar", leaking
+      // its "temporary" binding in mappings and addressMap.
+      ad.removeBinding(SimpleString.of(temporary), null);
+
+      // Verify no leaked bindings: "permanent" should be the only binding remaining on each address
+      fooBindings = ad.getBindingsForRoutingAddress(SimpleString.of(myAddress + "foo"));
+      barBindings = ad.getBindingsForRoutingAddress(SimpleString.of(myAddress + "bar"));
+      assertEquals(1, fooBindings.getBindings().size());
+      assertEquals(1, barBindings.getBindings().size());
+      assertEquals(permanent, fooBindings.getBindings().iterator().next().getUniqueName().toString());
+      assertEquals(permanent, barBindings.getBindings().iterator().next().getUniqueName().toString());
+   }
+
    @Test
    public void testConcurrentCalls() throws Exception {
       final WildcardConfiguration configuration = new WildcardConfiguration();


### PR DESCRIPTION
When a message is routed, the Bindings for the address is fetched from the address manager. If the Bindings doesn't already exist then it is created. Creating the bindings involves traversing the address tree map to find all matching wildcard addresses. When a matching address is found its bindings are copied.

Traversing the address tree map is performed without any kind of synchronization. Therefore, a concurrent operation to remove a binding can modify a wildcard address's Bindings mid-copy. This produces a Bindings that is missing the binding being concurrently removed. The removeBinding visitor then walks matching addresses to remove the binding from each, but fails with IllegalStateException on the address where the binding was never copied. This can also leak entires in addressMap & mappings eventually leading to OOME, since the exception aborts the visitor traversal and skips cleanup of remaining addresses.

- Add addressMapLock to synchronize the lazy-creation path in getBindingsForRoutingAddress with addBinding, removeBinding, removeAddressInfo, and clear. The common path (cache hit) does not acquire the lock.
- Catch IllegalStateException in the removeBinding visitor as defense-in-depth so that a missing binding does not abort the traversal and leak remaining entries.
- Add tests to reproduce the race: a deterministic test that simulates the inconsistent state and verifies the visitor handles the missing binding, and a concurrent stress test that exercises getBindingsForRoutingAddress against wildcard binding add/remove.