### PR TITLE
NO-JIRA fix race condition in test

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -890,8 +890,6 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          } else {
             analyzer = EmptyCriticalAnalyzer.getInstance();
          }
-
-         this.analyzer = analyzer;
       }
 
       /*
@@ -957,6 +955,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       };
 
       analyzer.addAction(criticalAction);
+      this.analyzer = analyzer;
    }
 
    private static void checkCriticalAnalyzerLogging() {


### PR DESCRIPTION
All the tests in `org.apache.activemq.artemis.core.server.impl.ActiveMQServerStartupTest` have a race condition where `org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl#getCriticalAnalyzer` becomes non-null *before* any actions are added so that when `org.apache.activemq.artemis.utils.critical.CriticalAnalyzerAccessor#fireActions` is called it might not actually do anything.

The fix is to wait until actions are added before assigning `org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl#analyzer` a value.