### PR TITLE
ARTEMIS-6203 make MQTT resiliency soak tests more robust

### DIFF
--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/Wait.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/Wait.java
@@ -78,7 +78,7 @@ public class Wait {
    }
 
    public static void assertEquals(Object obj, ObjectCondition condition) throws Exception {
-      assertEquals(obj, condition, MAX_WAIT_MILLIS, SLEEP_MILLIS);
+      assertEquals(obj, condition, MAX_WAIT_MILLIS, SLEEP_MILLIS, null);
    }
 
 
@@ -117,10 +117,14 @@ public class Wait {
 
 
    public static void assertEquals(Object obj, ObjectCondition condition, long timeout, long sleepMillis) throws Exception {
+      assertEquals(obj, condition, timeout, sleepMillis, null);
+   }
+
+   public static void assertEquals(Object obj, ObjectCondition condition, long timeout, long sleepMillis, Supplier<String> messageSupplier) throws Exception {
       boolean result = waitFor(() -> (obj == condition || (obj != null && obj.equals(condition.getObject()))), timeout, sleepMillis);
 
       if (!result) {
-         Assertions.assertEquals(obj, condition.getObject());
+         Assertions.assertEquals(obj, condition.getObject(), messageSupplier);
       }
    }
 

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/mqtt/resiliency/QoS2CombinedResiliencySoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/mqtt/resiliency/QoS2CombinedResiliencySoakTest.java
@@ -171,7 +171,7 @@ public class QoS2CombinedResiliencySoakTest extends QoS2ResiliencySoakTestSuppor
          String clientId = getClientId(subscriber);
          assertEquals(0, duplicatesPerSubscriber.get(clientId).size(), "Subscriber " + clientId + " received duplicates: " + duplicatesPerSubscriber.get(clientId));
          assertEquals(NUM_PUBLISHERS * NUM_MESSAGES, receivedPerSubscriber.get(clientId).size(), "Subscriber " + clientId + " didn't receive: " + getMissingMessages(publishResult.sentMessages(), receivedPerSubscriber.get(clientId)));
-         assertEquals(0L, getSubscriptionQueue(TOPIC, clientId).getMessageCount(), "Subscription queue for " + clientId + " has incorrect message count");
+         Wait.assertEquals(0L, () -> getSubscriptionQueue(TOPIC, clientId).getMessageCount(), 2000, 20, () -> "Subscription queue for " + clientId + " has incorrect message count");
          assertEquals(0, getProtocolManager().getStateManager().getPacketIdCorrelationSize(clientId));
          assertEquals(0, getSubCacheSize(clientId));
          cleanDisconnect(subscriber);

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/mqtt/resiliency/QoS2SubscriberResiliencySoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/mqtt/resiliency/QoS2SubscriberResiliencySoakTest.java
@@ -172,13 +172,13 @@ public class QoS2SubscriberResiliencySoakTest extends QoS2ResiliencySoakTestSupp
       // verify all expected messages received with no duplicates
       for (Mqtt5BlockingClient subscriber : subscribers) {
          String clientId = getClientId(subscriber);
-         assertEquals(0, duplicatesPerSubscriber.get(clientId).size(), "Subscriber " + getClientId(subscriber) + " received duplicates: " + duplicatesPerSubscriber.get(clientId));
-         assertEquals(NUM_MESSAGES, receivedPerSubscriber.get(clientId).size(), "Subscriber " + getClientId(subscriber) + " didn't receive: " + getMissingMessages(sentMessages, receivedPerSubscriber.get(clientId)));
-         assertEquals(0L, getSubscriptionQueue(TOPIC, getClientId(subscriber)).getMessageCount(), "Subscription queue for " + getClientId(subscriber) + " has incorrect message count");
-         assertEquals(0, getProtocolManager().getStateManager().getPacketIdCorrelationSize(getClientId(subscriber)));
-         assertEquals(0, getSubCacheSize(getClientId(subscriber)));
+         assertEquals(0, duplicatesPerSubscriber.get(clientId).size(), "Subscriber " + clientId + " received duplicates: " + duplicatesPerSubscriber.get(clientId));
+         assertEquals(NUM_MESSAGES, receivedPerSubscriber.get(clientId).size(), "Subscriber " + clientId + " didn't receive: " + getMissingMessages(sentMessages, receivedPerSubscriber.get(clientId)));
+         Wait.assertEquals(0L, () -> getSubscriptionQueue(TOPIC, clientId).getMessageCount(), 2000, 20, () -> "Subscription queue for " + clientId + " has incorrect message count");
+         assertEquals(0, getProtocolManager().getStateManager().getPacketIdCorrelationSize(clientId));
+         assertEquals(0, getSubCacheSize(clientId));
          cleanDisconnect(subscriber);
-         assertNull(getSubCache(getClientId(subscriber)), "Sub cache should be null after clean start for " + getClientId(subscriber));
+         assertNull(getSubCache(clientId), "Sub cache should be null after clean start for " + clientId);
       }
    }
 }


### PR DESCRIPTION
There is a race in the soak tests which focus on resiliency for MQTT subscribers. There is a small window in between when the subscriber receives the initial PUBLISH packet (and records the receipt of the message) and when the broker receives the PUBREC and acknowledges the message. It's possible that the test will attempt to verify that the message is acknowledged during this window and fail.

The fix is simply to use Wait to verify the acknowledgement.