### PR TITLE
ARTEMIS-6203 make MQTT resiliency soak tests more robust

### DIFF
--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/mqtt/resiliency/QoS2SubscriberResiliencySoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/mqtt/resiliency/QoS2SubscriberResiliencySoakTest.java
@@ -176,7 +176,7 @@ public class QoS2SubscriberResiliencySoakTest extends QoS2ResiliencySoakTestSupp
          assertEquals(NUM_MESSAGES, receivedPerSubscriber.get(clientId).size(), "Subscriber " + clientId + " didn't receive: " + getMissingMessages(sentMessages, receivedPerSubscriber.get(clientId)));
          Wait.assertEquals(0L, () -> getSubscriptionQueue(TOPIC, clientId).getMessageCount(), 2000, 20, () -> "Subscription queue for " + clientId + " has incorrect message count");
          assertEquals(0, getProtocolManager().getStateManager().getPacketIdCorrelationSize(clientId));
-         assertEquals(0, getSubCacheSize(clientId));
+         Wait.assertEquals(0, () -> getSubCacheSize(clientId), 2000, 20, () -> "Sub cache for " + clientId + " has incorrect size");
          cleanDisconnect(subscriber);
          assertNull(getSubCache(clientId), "Sub cache should be null after clean start for " + clientId);
       }


### PR DESCRIPTION
There is another race in the soak test which focuses on resiliency for MQTT subscribers. After the subscription queue message count reaches 0 the PUBREC DuplicateIDCache may still hold entries because the core message is acknowledged when the broker receives the PUBREC while the cache entry isn't removed until the broker receives the PUBCOMP one round-trip later. It's possible the test will verify the cache size during this window and fail.

The fix is simply to use Wait to verify the cache size.