### PR TITLE
ARTEMIS-6220 Emit scalar properties first

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -3950,15 +3950,29 @@ public class ConfigurationImpl extends javax.security.auth.login.Configuration i
             put(discriminatorKey, String.valueOf(classDiscriminator));
          }
 
+         // process scalar entries before nested maps — scalar setters must complete
+         // before nested property resolution triggers getters that may lazily depend on
+         // sibling scalar values (e.g., uri must be set before transportConfigurations
+         // is accessed, because getTransportConfigurations() lazily calls parseURI())
+         loadYamlEntries(keySurroundString, parentKey, map, false);
+         loadYamlEntries(keySurroundString, parentKey, map, true);
+      }
+
+      @SuppressWarnings("unchecked")
+      private void loadYamlEntries(String keySurroundString, String parentKey, Map<String, Object> map, boolean parseMaps) {
          for (Map.Entry<String, Object> entry : map.entrySet()) {
+            Object value = entry.getValue();
+            boolean isMap = value instanceof Map;
+            if (isMap != parseMaps) {
+               continue;
+            }
             String key = entry.getKey();
             if (JSON_CLASS_DISCRIMINATOR_KEY.equals(key)) {
                continue;
             }
             key = autoSurroundIfNecessary(key, keySurroundString);
             String propertyKey = parentKey + key;
-            Object value = entry.getValue();
-            if (value instanceof Map) {
+            if (isMap) {
                loadYamlMap(keySurroundString, propertyKey + ".", (Map<String, Object>) value);
             } else if (value instanceof List<?> list) {
                put(propertyKey, list.stream()
@@ -3990,6 +4004,15 @@ public class ConfigurationImpl extends javax.security.auth.login.Configuration i
             put(discriminatorKey, jsonObject.getString(JSON_CLASS_DISCRIMINATOR_KEY));
          }
 
+         // process scalar entries before nested objects — scalar setters must complete
+         // before nested property resolution triggers getters that may lazily depend on
+         // sibling scalar values (e.g., uri must be set before transportConfigurations
+         // is accessed, because getTransportConfigurations() lazily calls parseURI())
+         loadJsonEntries(keySurroundString, parentKey, jsonObject, false);
+         loadJsonEntries(keySurroundString, parentKey, jsonObject, true);
+      }
+
+      private void loadJsonEntries(String keySurroundString, String parentKey, JsonObject jsonObject, boolean parseObjects) {
          jsonObject.entrySet().stream().forEach(jsonEntry -> {
             String jsonKey = jsonEntry.getKey();
             if (JSON_CLASS_DISCRIMINATOR_KEY.equals(jsonKey)) {
@@ -3997,6 +4020,10 @@ public class ConfigurationImpl extends javax.security.auth.login.Configuration i
             }
             JsonValue jsonValue = jsonEntry.getValue();
             JsonValue.ValueType jsonValueType = jsonValue.getValueType();
+            boolean isObject = jsonValueType == JsonValue.ValueType.OBJECT;
+            if (isObject != parseObjects) {
+               return;
+            }
             jsonKey = autoSurroundIfNecessary(jsonKey, keySurroundString);
             String propertyKey = parentKey + jsonKey;
             switch (jsonValueType) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/AbstractConfigurationFullTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/AbstractConfigurationFullTest.java
@@ -455,9 +455,10 @@ public abstract class AbstractConfigurationFullTest {
 
    @Test
    public void testAMQPConnections() {
-      assertEquals(1, configuration.getAMQPConnections().size());
-      AMQPBrokerConnectConfiguration amqp = configuration.getAMQPConnections().get(0);
-      assertEquals("mirror-target", amqp.getName());
+      assertEquals(2, configuration.getAMQPConnections().size());
+      AMQPBrokerConnectConfiguration amqp = configuration.getAMQPConnections().stream()
+         .filter(c -> "mirror-target".equals(c.getName())).findFirst().orElse(null);
+      assertNotNull(amqp);
       assertEquals("tcp://mirror-host:5672", amqp.getUri());
       assertEquals(5000, amqp.getRetryInterval());
       assertEquals(-1, amqp.getReconnectAttempts());
@@ -475,6 +476,27 @@ public abstract class AbstractConfigurationFullTest {
       assertEquals("orders", mirror.getAddressFilter());
       assertTrue(mirror.isSync());
       assertEquals("mirrorVal1", mirror.getProperties().get("mirrorProp1"));
+
+      AMQPBrokerConnectConfiguration reversed = configuration.getAMQPConnections().stream()
+         .filter(c -> "reversed-order-target".equals(c.getName())).findFirst().orElse(null);
+      assertNotNull(reversed, "reversed-order-target AMQP connection must load even with objects before scalars in JSON/YAML");
+      assertEquals("tcp://reversed-host:5672", reversed.getUri());
+      assertEquals(10000, reversed.getRetryInterval());
+      assertEquals(5, reversed.getReconnectAttempts());
+      assertEquals("reversed-user", reversed.getUser());
+      assertEquals("reversed-password", reversed.getPassword());
+      assertTrue(reversed.isAutostart());
+
+      assertEquals(1, reversed.getConnectionElements().size());
+      assertTrue(reversed.getConnectionElements().get(0) instanceof AMQPMirrorBrokerConnectionElement);
+      AMQPMirrorBrokerConnectionElement mirrorReversed = (AMQPMirrorBrokerConnectionElement) reversed.getConnectionElements().get(0);
+      assertEquals("mirror-reversed", mirrorReversed.getName());
+      assertFalse(mirrorReversed.isMessageAcknowledgements());
+      assertTrue(mirrorReversed.isQueueCreation());
+      assertTrue(mirrorReversed.isQueueRemoval());
+      assertEquals("events", mirrorReversed.getAddressFilter());
+      assertFalse(mirrorReversed.isSync());
+      assertEquals("reversedVal1", mirrorReversed.getProperties().get("reversedProp1"));
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -2626,6 +2626,43 @@ public class ConfigurationImplTest extends AbstractConfigurationTestBase {
    }
 
    @Test
+   public void testJsonAMQPConnectionUriOrderIndependent() throws Exception {
+      // transportConfigurations appears BEFORE uri in JSON — this simulates what happens
+      // when a JSON serializer sorts keys alphabetically (e.g., Go's json.Marshal),
+      // since "transportConfigurations" < "uri" lexically.
+      // Without the scalars-before-objects fix, getTransportConfigurations() lazily calls
+      // parseURI() before uri is set, causing trustStorePassword to be silently lost.
+      File tmpFile = File.createTempFile("amqp-uri-order-test", ".json", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+
+         printWriter.write("{\n");
+         printWriter.write("  \"AMQPConnections\" : {\n");
+         printWriter.write("    \"target\" : {\n");
+         printWriter.write("      \"transportConfigurations\" : {\n");
+         printWriter.write("        \"target\" : {\n");
+         printWriter.write("          \"params\" : { \"trustStorePassword\" : \"pass\"\n }\n");
+         printWriter.write("        }\n");
+         printWriter.write("      },\n");
+         printWriter.write("      \"uri\" : \"tcp://host:6449?trustStorePath=/client.ts\"\n");
+         printWriter.write("    }\n");
+         printWriter.write("  }\n");
+         printWriter.write("}\n");
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      String matchNoErrors = "\"errors\":\\[]";
+      assertEquals(3, configuration.getStatus().split(matchNoErrors, 10).length, configuration.getStatus());
+
+      Map<String, Object> params = configuration.getAMQPConnections().get(0).getTransportConfigurations().get(0).getParams();
+      assertEquals(4, params.size(), "Expected 4 params: host, port, trustStorePath (from URI), trustStorePassword (explicit)");
+      assertEquals("/client.ts", params.get("trustStorePath"));
+      assertEquals("pass", params.get("trustStorePassword"));
+   }
+
+   @Test
    public void testTextPropertiesReaderFromFile() throws Exception {
       List<String> textProperties = buildSimpleConfigTextList();
       File tmpFile = File.createTempFile("text-props-test", "", temporaryFolder);

--- a/artemis-server/src/test/resources/broker-full-config.json
+++ b/artemis-server/src/test/resources/broker-full-config.json
@@ -343,6 +343,27 @@
           }
         }
       }
+    },
+    "reversed-order-target": {
+      "mirrors": {
+        "mirror-reversed": {
+          "properties": {
+            "reversedProp1": "reversedVal1"
+          },
+          "type": "MIRROR",
+          "messageAcknowledgements": false,
+          "queueCreation": true,
+          "queueRemoval": true,
+          "addressFilter": "events",
+          "sync": false
+        }
+      },
+      "uri": "tcp://reversed-host:5672",
+      "retryInterval": 10000,
+      "reconnectAttempts": 5,
+      "user": "reversed-user",
+      "password": "reversed-password",
+      "autostart": true
     }
   },
 

--- a/artemis-server/src/test/resources/broker-full-config.yaml
+++ b/artemis-server/src/test/resources/broker-full-config.yaml
@@ -321,6 +321,23 @@ AMQPConnections:
         sync: true
         properties:
           mirrorProp1: "mirrorVal1"
+  reversed-order-target:
+    mirrors:
+      mirror-reversed:
+        properties:
+          reversedProp1: "reversedVal1"
+        type: "MIRROR"
+        messageAcknowledgements: false
+        queueCreation: true
+        queueRemoval: true
+        addressFilter: "events"
+        sync: false
+    uri: "tcp://reversed-host:5672"
+    retryInterval: 10000
+    reconnectAttempts: 5
+    user: "reversed-user"
+    password: "reversed-password"
+    autostart: true
 
 HAPolicyConfiguration: "PRIMARY_ONLY"
 


### PR DESCRIPTION
Split loadJsonObject/loadYamlMap into two passes — scalars first, then nested objects — so that discriminator values like uri are always set before a lazy-init getter (e.g. getTransportConfigurations) can fire during object path resolution. Without this, key ordering in the source file could cause silent data loss.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>