### PR TITLE
ARTEMIS-6225 Bump selenium.version from 4.47.0 to 4.48.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
       <hive.client.mqtt.version>1.4.0</hive.client.mqtt.version>
       <postgresql.version>42.7.13</postgresql.version>
       <testcontainers.version>1.21.4</testcontainers.version>
-      <selenium.version>4.47.0</selenium.version>
+      <selenium.version>4.48.0</selenium.version>
       <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
       <apache.httpcore.version>4.4.16</apache.httpcore.version>
       <apache.httpclient.version>4.5.14</apache.httpclient.version>


### PR DESCRIPTION
Automated replacement for #6655, carrying the required Jira reference ARTEMIS-6225.

Original Dependabot PR: #6655
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6225