### PR TITLE
ARTEMIS-6227 Bump org.apache.groovy:groovy-all from 5.1.0 to 5.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 
       <!-- used on tests -->
       <elementary.version>3.0.0</elementary.version>
-      <groovy.version>5.1.0</groovy.version>
+      <groovy.version>5.1.1</groovy.version>
       <hadoop.minikdc.version>3.5.0</hadoop.minikdc.version>
       <mockserver.version>7.6.0</mockserver.version>
 


### PR DESCRIPTION
Automated replacement for #6650, carrying the required Jira reference ARTEMIS-6227.

Original Dependabot PR: #6650
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6227