### PR TITLE
ARTEMIS-6228 Bump org.easymock:easymock from 5.6.0 to 5.7.0

### DIFF
--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -61,7 +61,7 @@
          <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.0</version>
             <scope>test</scope>
          </dependency>
 


### PR DESCRIPTION
Automated replacement for #6647, carrying the required Jira reference ARTEMIS-6228.

Original Dependabot PR: #6647
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6228