### PR TITLE
ARTEMIS-6229 Bump org.apache.felix:maven-bundle-plugin from 6.1.0 to 6.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
       <jetty-servlet-api.version>5.0.2</jetty-servlet-api.version>
       <jgroups.version>5.3.13.Final</jgroups.version>
       <errorprone.version>2.50.0</errorprone.version>
-      <maven.bundle.plugin.version>6.1.0</maven.bundle.plugin.version>
+      <maven.bundle.plugin.version>6.1.2</maven.bundle.plugin.version>
       <jib.maven.plugin.version>3.5.2</jib.maven.plugin.version>
       <versions.maven.plugin.version>2.16.1</versions.maven.plugin.version>
       <maven.pmd.plugin.version>3.28.0</maven.pmd.plugin.version>


### PR DESCRIPTION
Automated replacement for #6667, carrying the required Jira reference ARTEMIS-6229.

Original Dependabot PR: #6667
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6229