### PR TITLE
ARTEMIS-6236 Bump activemq5-version from 5.19.10 to 5.19.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
       <pax.exam.version>4.14.0</pax.exam.version>
       <commons.config.version>2.15.1</commons.config.version>
       <commons.lang.version>3.20.0</commons.lang.version>
-      <activemq5-version>5.19.10</activemq5-version>
+      <activemq5-version>5.19.11</activemq5-version>
       <apache.derby.version>10.15.2.0</apache.derby.version>
       <commons.beanutils.version>1.11.0</commons.beanutils.version>
       <commons.logging.version>1.4.0</commons.logging.version>

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/region/policy/DestinationProxy.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/region/policy/DestinationProxy.java
@@ -713,4 +713,9 @@ public class DestinationProxy implements Destination {
    public void setAdvancedMessageStatisticsEnabled(boolean advancedMessageStatisticsEnabled) {
       throw new UnsupportedOperationException("Not implemented yet");
    }
+
+   @Override
+   public boolean isGcWithOnlyWildcardConsumers() {
+      return false;
+   }
 }


### PR DESCRIPTION
Automated replacement for #6674, carrying the required Jira reference ARTEMIS-6236.

Original Dependabot PR: #6674
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6236