### PR TITLE
ARTEMIS-6226 Bump jline.version from 4.4.1 to 4.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
       <hawtbuff.version>1.11</hawtbuff.version>
       <hawtdispatch.version>1.22</hawtdispatch.version>
       <picocli.version>4.7.7</picocli.version>
-      <jline.version>4.4.1</jline.version>
+      <jline.version>4.4.2</jline.version>
       <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
       <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
       <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>


### PR DESCRIPTION
Automated replacement for #6673, carrying the required Jira reference ARTEMIS-6226.

Original Dependabot PR: #6673
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6226