### PR TITLE
ARTEMIS-6227 Bump org.apache.groovy:groovy-all from 5.1.1 to 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 
       <!-- used on tests -->
       <elementary.version>3.0.0</elementary.version>
-      <groovy.version>5.1.1</groovy.version>
+      <groovy.version>5.1.2</groovy.version>
       <hadoop.minikdc.version>3.5.0</hadoop.minikdc.version>
       <mockserver.version>7.6.0</mockserver.version>
 


### PR DESCRIPTION
Automated replacement for #6679, carrying the required Jira reference ARTEMIS-6227.

Original Dependabot PR: #6679
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6227