### PR TITLE
ARTEMIS-6238 Bump jetty.version from 12.1.12 to 12.1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
       <caffeine.version>3.2.4</caffeine.version>
       <guava.version>33.7.1-jre</guava.version>
       <jsr305.version>3.0.2</jsr305.version>
-      <jetty.version>12.1.12</jetty.version>
+      <jetty.version>12.1.13</jetty.version>
       <jetty-servlet-api.version>5.0.2</jetty-servlet-api.version>
       <jgroups.version>5.3.13.Final</jgroups.version>
       <errorprone.version>2.50.0</errorprone.version>


### PR DESCRIPTION
Automated replacement for #6678, carrying the required Jira reference ARTEMIS-6238.

Original Dependabot PR: #6678
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6238