### PR TITLE
ARTEMIS-6239 Bump slf4j.version from 2.0.18 to 2.0.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
       <netty-tcnative-version>2.0.83.Final</netty-tcnative-version>
       <proton.version>0.35.0</proton.version>
       <protonj2.version>1.3.0</protonj2.version>
-      <slf4j.version>2.0.18</slf4j.version>
+      <slf4j.version>2.0.19</slf4j.version>
       <log4j.version>2.26.1</log4j.version>
       <qpid.jms.version>1.17.0</qpid.jms.version>
       <johnzon.version>1.3.0</johnzon.version>


### PR DESCRIPTION
Automated replacement for #6677, carrying the required Jira reference ARTEMIS-6239.

Original Dependabot PR: #6677
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6239