### PR TITLE
ARTEMIS-6250 Bump org.apache.maven.plugin-tools:maven-plugin-annotations from 3.15.2 to 3.16.0

### DIFF
--- a/artemis-maven-plugin/pom.xml
+++ b/artemis-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 
    <properties>
       <plugin.components.maven.version>3.9.16</plugin.components.maven.version>
-      <plugin.annotations.version>3.15.2</plugin.annotations.version>
+      <plugin.annotations.version>3.16.0</plugin.annotations.version>
    </properties>
 
    <dependencies>


### PR DESCRIPTION
Automated replacement for #6686, carrying the required Jira reference ARTEMIS-6250.

Original Dependabot PR: #6686
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6250