### PR TITLE
ARTEMIS-6224 Bump io.netty:netty-tcnative-boringssl-static from 2.0.83.Final to 2.0.84.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <asciidoctorj.pdf.version>2.3.23</asciidoctorj.pdf.version>
 
       <!-- this is basically for tests -->
-      <netty-tcnative-version>2.0.83.Final</netty-tcnative-version>
+      <netty-tcnative-version>2.0.84.Final</netty-tcnative-version>
       <proton.version>0.35.0</proton.version>
       <protonj2.version>1.3.0</protonj2.version>
       <slf4j.version>2.0.19</slf4j.version>


### PR DESCRIPTION
Automated replacement for #6691, carrying the required Jira reference ARTEMIS-6224.

Original Dependabot PR: #6691
Jira: https://issues.apache.org/jira/browse/ARTEMIS-6224